### PR TITLE
Added support for togglr descriptions.

### DIFF
--- a/bin/togglr
+++ b/bin/togglr
@@ -42,7 +42,7 @@ module ToggleCLI
           end
         }
 
-        desc "#{toggle.name} [on|off|state]", 'manage state of toggles'
+        desc "#{toggle.name} [on|off|state]", (toggle.description || 'manage state of toggles')
         desc 'on', "Toggle on the #{toggle.name} feature"
         def on
           toggle.active = true
@@ -57,10 +57,15 @@ module ToggleCLI
         def state
           puts toggle.active? ? 'on' : 'off'
         end
+
+        desc 'desc', "Shows the description of the #{toggle.name} toggle"
+        def description
+          puts toggle.description
+        end
       end
 
       #register(klass, "#{toggle.name}", "#{toggle.name} [on|off|state]", "manage state of toggles")
-      desc "#{toggle.name} [on|off|state]", 'manage state of toggles'
+      desc "#{toggle.name} [on|off|state]", (toggle.description || 'manage state of toggles')
       subcommand "#{toggle.name}", klass
     end
   end

--- a/fig.yml.template
+++ b/fig.yml.template
@@ -1,5 +1,5 @@
 app:
-  image: docker-registry.in.jqdev.net/hooroo-base-ruby-${RUBY_VERSION}:184
+  image: docker-registry.in.jqdev.net/hooroo-base-ruby-${RUBY_VERSION}:186
   environment:
     TZ: Australia/Melbourne
     LANG: en_US.UTF-8

--- a/lib/togglr/base_toggle.rb
+++ b/lib/togglr/base_toggle.rb
@@ -1,10 +1,17 @@
 module Togglr
   class BaseToggle
-    attr_reader :name
+    attr_reader :name, :description
 
-    def initialize(name, default_value, repositories)
+    def initialize(name, properties, repositories)
       @name = name
-      @default_value = default_value
+
+      if properties.is_a? Hash
+        @default_value = properties[:value] || false
+        @description = properties[:description] || "#{name} toggle"
+      else
+        @default_value = properties
+      end
+
       @repositories = repositories
     end
 

--- a/lib/togglr/toggles.rb
+++ b/lib/togglr/toggles.rb
@@ -6,8 +6,8 @@ module Togglr
     include Singleton
 
     def self.register_toggles(toggles=toggles_source.toggles)
-      toggles.each do |name, value|
-        register_toggle(name, value)
+      toggles.each do |name, properties|
+        register_toggle(name, properties)
       end
     end
 
@@ -28,7 +28,7 @@ module Togglr
     private
 
       def self.register_toggle(name, properties)
-        f = toggle_class.new(name, properties[:value], repositories)
+        f = toggle_class.new(name, properties, repositories)
         instance.toggles << f
         define_singleton_method("#{name}?") do
           f.active?

--- a/spec/togglr/base_toggle_spec.rb
+++ b/spec/togglr/base_toggle_spec.rb
@@ -10,7 +10,6 @@ module Togglr
     let(:toggle) { BaseToggle.new(toggle_name, toggle_value, repositories) }
 
 
-
     describe '#active?' do
       context 'without any repositories' do
         it 'returns the default value' do
@@ -81,6 +80,23 @@ module Togglr
         end
       end
 
+    end
+
+    describe '#description' do
+      let(:toggle_value) { { value: true, description: description } }
+      context 'when supplied a description' do
+        let(:description) {  'This is the description' }
+        it 'returns the given description' do
+          expect(toggle.description).to eq description
+        end
+      end
+
+      context 'when not supplied a description' do
+        let(:description) { nil }
+        it 'returns a default description' do
+          expect(toggle.description).to_not eq description
+        end
+      end
     end
 
   end

--- a/spec/togglr/yaml_reader_spec.rb
+++ b/spec/togglr/yaml_reader_spec.rb
@@ -8,6 +8,7 @@ module Togglr
 :category:
   :true_toggle:
     :value: true
+    :description: desc
   :false_toggle:
     :value: false
 }
@@ -35,7 +36,7 @@ module Togglr
     describe '#toggles' do
 
       it 'returns toggles with initial state' do
-        expect(yaml_reader.toggles).to eq({true_toggle: {value: true, category: :category}, false_toggle: {value: false, category: :category}})
+        expect(yaml_reader.toggles).to eq({true_toggle: {value: true, category: :category, description: 'desc'}, false_toggle: {value: false, category: :category}})
       end
 
       it 'returns a hash' do
@@ -82,4 +83,5 @@ module Togglr
     end
 
   end
+
 end


### PR DESCRIPTION
This allows me to tell my future self what I inteded with the toggle at conception.

```yaml
---
:application:
  :toggle:
    :value: true
    :description: Jacob was here
```
```ruby
toggle.description
# => Jacob was here
```